### PR TITLE
Fix kill and damage counters related to Update 205

### DIFF
--- a/lua/DamagePopup.lua
+++ b/lua/DamagePopup.lua
@@ -1,4 +1,5 @@
-if RequiredScript == "lib/units/enemies/cop/copdamage" then
+if RequiredScript == "lib/units/enemies/cop/copdamage"  and not CopDamage._damage_popup_loaded then
+    CopDamage._damage_popup_loaded = true
 	local _on_damage_received_original = CopDamage._on_damage_received
 	--Workaround for Teammate Headshots, since col_ray doesn't get forwarded...  (self._sync_ibody_popup)
 	local sync_damage_bullet_original = CopDamage.sync_damage_bullet

--- a/lua/GameInfoManager.lua
+++ b/lua/GameInfoManager.lua
@@ -2136,7 +2136,8 @@ if string.lower(RequiredScript) == "lib/network/handlers/unitnetworkhandler" the
 
 end
 
-if string.lower(RequiredScript) == "lib/units/enemies/cop/copdamage" then
+if string.lower(RequiredScript) == "lib/units/enemies/cop/copdamage" and not CopDamage._game_info_manager_loaded then
+    CopDamage._game_info_manager_loaded = true
 
 	local convert_to_criminal_original = CopDamage.convert_to_criminal
 	local _on_damage_received_original = CopDamage._on_damage_received

--- a/lua/KillCounter.lua
+++ b/lua/KillCounter.lua
@@ -1,4 +1,5 @@
-if RequiredScript == "lib/units/enemies/cop/copdamage" then
+if RequiredScript == "lib/units/enemies/cop/copdamage" and not CopDamage._kill_counter_loaded then
+    CopDamage._kill_counter_loaded = true
 
 	--This needs fixing for DoT kills (then again, so does the games own kill counter) as client somehow and a lot of testing
 

--- a/lua/TabStats.lua
+++ b/lua/TabStats.lua
@@ -1162,7 +1162,9 @@ elseif string.lower(RequiredScript) == "lib/managers/statisticsmanager" then
 		local peer_name = user_id and Steam:username(user_id) or managers.localization:text("debug_undecided")
 		return string.format("%s (%s)", peer_name, managers.money:add_decimal_marks_to_string(tostring(max_damage)))
 	end
-elseif string.lower(RequiredScript) == "lib/units/enemies/cop/copdamage" then
+elseif string.lower(RequiredScript) == "lib/units/enemies/cop/copdamage" and not CopDamage._tab_stats_loaded then
+    CopDamage._tab_stats_loaded = true
+
 	local _on_damage_received_original = CopDamage._on_damage_received
 
 	function CopDamage:_on_damage_received(damage_info, ...)


### PR DESCRIPTION
# Description

`lib/managers/statisticsmanager` now requires `lib/units/enemies/cop/CopDamage` as seen [here](https://github.com/mwSora/payday-2-luajit/commit/d3c7f364a5a1d6c21469bfd95cf599bb1646d42e#diff-67cbe58e3c31bbdd35061d98c3a8bf78e86155022b9bdd7a80c3cf8fa6e9590bR2) which causes Wolfhud to hook into the cop damage events twice in `DamagePopup.lua`, `KillCounter.lua`, `TabStats.lua`, and `GameInfoManager.lua`. This commit causes WolfHUD to check to see if the the given file has already been loaded before adding the hooks.